### PR TITLE
Fixed SSH Issue

### DIFF
--- a/RaspImgConfig.sh
+++ b/RaspImgConfig.sh
@@ -36,6 +36,7 @@ export RIC_SUMM_FILE="summary.conf"
 export RIC_NC_SERVER="nc_server.sh"
 export RIC_NC_PORT="23871"
 export RIC_IMG_FILE_NAME="raspimg.img"
+export RIC_SSH_ENABLE_FILE="ssh"
 
 
 ric_is_root()
@@ -695,6 +696,13 @@ ric_configure()
     if [ "$?" != "0" ]
     then
         echo "Could not write WiFi settings."
+    fi
+	# https://www.raspberrypi.org/documentation/remote-access/ssh/
+	# Fix for enabling ssh
+	touch mo1/$RIC_SSH_ENABLE_FILE 
+    if [ "$?" != "0" ]
+    then
+        echo "Could not write ssh file to Enable SSH."
     fi
     ric_nc_server
     ric_prep_cfg_summ


### PR DESCRIPTION
As of the November 2016 release, Raspbian has the SSH server disabled by default. Please refer the below article https://www.raspberrypi.org/documentation/remote-access/ssh/
Fixed the issue.